### PR TITLE
Upgrade to Nixpkgs v24.11, GHC v9.6.6, Fix Static Build

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -9,7 +9,7 @@
 ## `--enable-executable-stripping`, hence the `strip` command usage.
 
 ## GHC version:
-GHC_VERSION="9.4.8"
+GHC_VERSION="9.6.6"
 
 ## Docker image:
 DOCKER_IMAGE="quay.io/benz0li/ghc-musl:${GHC_VERSION}"

--- a/default.nix
+++ b/default.nix
@@ -101,6 +101,7 @@ let
       pkgs.nil
       pkgs.nixpkgs-fmt
       pkgs.nodePackages.prettier
+      pkgs.upx
 
       ## Our custom development stuff:
       dev-test-build

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "release-24.05",
+        "branch": "release-24.11",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29c3451c88250659c4dccf3468523c00ed530c07",
-        "sha256": "19qrl1bb9m5bdgpq5pcpd2yd22h7vllcxcinmwlwj8c6v76dyk1s",
+        "rev": "da1dc2d645cc7aef7458588dc94435c3b13da2aa",
+        "sha256": "06a3aisyb92w8m24igg0pv4n53ffwxa3y4kvds44d0ha95iwb79s",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/29c3451c88250659c4dccf3468523c00ed530c07.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/da1dc2d645cc7aef7458588dc94435c3b13da2aa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
- **fix(deps): upgrade nixpkgs to v24.11**
- **fix(deps): use ghc 9.6.6 for static builds**
- **fix(build): add upx to Nix shell for static build**
